### PR TITLE
avoid anomolies when a hint database doesn't exist

### DIFF
--- a/src/g_ltac_iter.ml4
+++ b/src/g_ltac_iter.ml4
@@ -70,10 +70,14 @@ struct
       | Reverse c -> resolve_collection (not reverse) c
       | HintDb db_name ->
         let db =
-          let syms = ref [] in
-          let db = Hints.searchtable_map db_name in
-          Hints.Hint_db.iter (fun _ _ hl -> syms := hl :: !syms) db ;
-          !syms
+          try
+            let db = Hints.searchtable_map db_name in
+            let syms = ref [] in
+            Hints.Hint_db.iter (fun _ _ hl -> syms := hl :: !syms) db ;
+            !syms
+          with Not_found ->
+            let _ = Tacticals.tclIDTAC_MESSAGE Pp.(str "Hint database " ++ str db_name ++ str " not found!") in
+            []
         in
         if reverse then
           Proofview.Goal.nf_enter begin fun gl ->

--- a/test-suite/example.v
+++ b/test-suite/example.v
@@ -40,3 +40,8 @@ Goal False -> True -> 1 = 1 -> True.
   foreach [ rev *|- ] k.
   exact I.
 Defined.
+
+Goal True.
+  foreach [ db:does_not_exist ] ltac:(fun x => idtac x).
+  exact I.
+Defined.


### PR DESCRIPTION
The solution here is to print a warning but treat the database as empty.